### PR TITLE
Update create-build to merge only when directed

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ In this example we will build the system for a Raspberry Pi 4 with the docker pl
 First lets build the initramfs
 
 ```bash
-./tools/scripts/create-build.sh initramfs/aarch64_defconfig o/initramfs-aarch64
+./tools/scripts/create-build.sh o/initramfs-aarch64 initramfs/aarch64_defconfig
 cd o/initramfs-aarch64
 make
 ```
@@ -21,15 +21,14 @@ make
 Next build the target system
 
 ```bash
-./tools/scripts/create-build.sh targets/rpi4/defconfig o/rpi4
+./tools/scripts/create-build.sh o/rpi4 targets/rpi4/defconfig tools/buildroot-external-peridio-platform/configs/peridio_platform_defconfig
 cd o/rpi4
 make
-```
 
 Finally, merge together the docker platform example and produce a fw file
 
 ```bash
-cd 
+cd
 o/rpi4/images/platform-build.sh peridio-reference-platform-rpi4.fw platforms/docker
 ```
 

--- a/docs/_internal/CI.md
+++ b/docs/_internal/CI.md
@@ -13,7 +13,7 @@ export VERSION=$(cat $VERSION)
 
 ```bash
 export INITRAMFS_ARCH=$(cat targets/$TARGET)
-./tools/scripts/create-build.sh initramfs/${INITRAMFS_ARCH}_defconfig o/initramfs-${INITRAMFS_ARCH}
+./tools/scripts/create-build.sh o/initramfs-${INITRAMFS_ARCH} initramfs/${INITRAMFS_ARCH}_defconfig
 cd o/initramfs-${INITRAMFS_ARCH}
 make
 ```
@@ -21,7 +21,7 @@ make
 Next build the target system
 
 ```bash
-./tools/scripts/create-build.sh targets/$TARGET/defconfig o/$TARGET
+./tools/scripts/create-build.sh o/$TARGET targets/$TARGET/defconfig tools/buildroot-external-peridio-platform/configs/peridio_platform_defconfig
 cd o/$TARGET
 make
 ```

--- a/tools/scripts/create-build.sh
+++ b/tools/scripts/create-build.sh
@@ -4,8 +4,8 @@
 # Create and initialize a directory for building a custom Buildroot.
 #
 # Inputs:
-#   $1 = the path to the configuration file (a _defconfig file)
-#   $2 = the build directory
+#   $1 = the build directory
+# . $n = the path to a configuration file (_defconfig file)
 #
 # Output:
 #   An initialized build directory on success
@@ -16,8 +16,8 @@ set -e
 
 BUILDROOT_VERSION=2022.08.1
 
-DEFCONFIG=$1
-BUILD_DIR=$2
+BUILD_DIR=$1
+DEFCONFIG=$2
 
 # "readlink -f" implementation for BSD
 # This code was extracted from the Elixir shell scripts
@@ -36,10 +36,6 @@ if [[ -z $DEFCONFIG ]]; then
     echo
     echo "  $0 <defconfig> [build directory]"
     exit 1
-fi
-
-if [[ -z $BUILD_DIR ]]; then
-    BUILD_DIR=o/$(basename -s _defconfig "$DEFCONFIG")
 fi
 
 # Create the build directory if it doesn't already exist
@@ -135,11 +131,11 @@ elif ! diff "$BUILDROOT_STATE_FILE" "$BUILDROOT_EXPECTED_STATE_FILE" >/dev/null;
     create_buildroot_dir
 fi
 
-# Merge the defconfig
+# Merge the defconfigs
+
 KCONFIG_CONFIG=$ABS_BUILD_DIR/defconfig
 KCONFIG_CONFIG=$KCONFIG_CONFIG \
-$BUILDROOT_DIR/support/kconfig/merge_config.sh -m \
-$ABS_DEFCONFIG $PERIDIO_EXTERNAL_PLATFORM/configs/peridio_platform_defconfig
+$BUILDROOT_DIR/support/kconfig/merge_config.sh -m ${*:2}
 
 # Configure the build directory - finally!
 BUILDROOT_EXTERNAL="$PERIDIO_EXTERNAL_PLATFORM:$PERIDIO_EXTERNAL"


### PR DESCRIPTION
Change the order of arguments in the create-build script so that multiple defconfigs can be specified. If multiple defconfigs are specified, they will be merged. This fixes an issue where the initramfs was being bloated with unnecessary applications and libraries.